### PR TITLE
Update import style to add RN 40.0+ compatibility

### DIFF
--- a/ios/RNInstabugSDK.h
+++ b/ios/RNInstabugSDK.h
@@ -7,9 +7,16 @@
 //
 
 
-#import "RCTBridgeModule.h"
-#import "RCTConvert.h"
-#import "RCTUtils.h"
+#if __has_include("RCTBridgeModule.h")
+  #import "RCTBridgeModule.h"
+  #import "RCTConvert.h"
+  #import "RCTUtils.h"
+#else
+  #import "React/RCTBridgeModule.h"
+  #import "React/RCTConvert.h"
+  #import "React/RCTUtils.h"
+#endif
+
 
 
 @interface RNInstabugSDK : NSObject <RCTBridgeModule>


### PR DESCRIPTION
Starting from RN 40.0, the import syntax has changed.

Including React header files now requires to be namespaced with `React/` prefix.
Read **Breaking Changes** in [RN 40.0 release notes](https://github.com/facebook/react-native/releases/tag/v0.40.0).

I did it in a way that `react-native-instabug-sdk` is still compatible with older versions of React Native  < 40.0.